### PR TITLE
Update from Debian 9 to 11

### DIFF
--- a/scripts/all.rb
+++ b/scripts/all.rb
@@ -39,6 +39,6 @@ def init_all(config, settings)
 
     config.trigger.before :halt do |trigger|
         trigger.info = "stop docker stack..."
-        trigger.run_remote = {inline: "cd /vagrant/docker/run; docker-compose down"}
+        trigger.run_remote = {inline: "cd /vagrant/docker/run; docker compose down"}
     end
 end

--- a/scripts/init-base-vm.rb
+++ b/scripts/init-base-vm.rb
@@ -1,27 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# see this issue: https://github.com/dotless-de/vagrant-vbguest/issues/351
-class WorkaroundVbguest < VagrantVbguest::Installers::Linux
-    def install(opts=nil, &block)
-      puts 'Executing update workaround (system and kernel upgrade)...'
-      communicate.sudo('apt-get -y --force-yes update', (opts || {}).merge(:error_check => false), &block)
-      communicate.sudo('apt-get -y --force-yes upgrade', (opts || {}).merge(:error_check => false), &block)
-      communicate.sudo('apt-get -y install build-essential linux-headers-amd64 linux-image-amd64', (opts || {}).merge(:error_check => false), &block)
-      puts 'Continue vbguest installation...'
-      super
-      puts 'Perform vbguest post installation steps...'
-      communicate.sudo('usermod -a -G vboxsf vagrant', (opts || {}).merge(:error_check => false), &block)
-    end
-    def reboot_after_install?(opts=nil, &block)
-      true
-    end
-end
-
 def init_base_vm(config)
-    config.vm.box = "debian/contrib-stretch64"
+    config.vm.box = "bento/debian-11"
     config.vm.box_check_update = false
-    config.vbguest.installer = WorkaroundVbguest
 
     config.ssh.username = "vagrant"
 end

--- a/scripts/prov-install-docker.rb
+++ b/scripts/prov-install-docker.rb
@@ -13,8 +13,14 @@ def prov_install_docker(config)
         sudo apt-get install -y docker-ce docker-ce-cli containerd.io
         getent group docker >/dev/null || sudo groupadd docker
         sudo usermod -aG docker vagrant
+
         sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
         sudo chmod +x /usr/local/bin/docker-compose
+
+        DOCKER_CONFIG=${DOCKER_CONFIG:-/usr/libexec/docker}
+        sudo mkdir -p $DOCKER_CONFIG/cli-plugins
+        sudo curl -SL https://github.com/docker/compose/releases/download/v2.4.0/docker-compose-linux-$(uname -m) -o $DOCKER_CONFIG/cli-plugins/docker-compose
+        sudo chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
 SCRIPT
     config.vm.provision "install-docker", type: "shell", privileged: false, reset: true, inline: $script
 end

--- a/scripts/prov-install-docker.rb
+++ b/scripts/prov-install-docker.rb
@@ -4,17 +4,16 @@
 def prov_install_docker(config)
     $script = <<-SCRIPT
         sudo apt-get update
-        sudo apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common curl
-        curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
-        sudo add-apt-repository \
-           "deb [arch=amd64] https://download.docker.com/linux/debian \
-           $(lsb_release -cs) \
-           stable"
+        sudo apt-get -y install ca-certificates curl gnupg2 curl lsb-release software-properties-common apt-transport-https apt-utils
+        curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+        echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
         sudo apt-get update
         sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-        sudo groupadd docker
+        getent group docker >/dev/null || sudo groupadd docker
         sudo usermod -aG docker vagrant
-        sudo curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
         sudo chmod +x /usr/local/bin/docker-compose
 SCRIPT
     config.vm.provision "install-docker", type: "shell", privileged: false, reset: true, inline: $script

--- a/tools/docker-compose.sh
+++ b/tools/docker-compose.sh
@@ -1,1 +1,1 @@
-vagrant ssh -c "cd /vagrant/docker/run && docker-compose $1 $2 $3"
+vagrant ssh -c "cd /vagrant/docker/run && docker compose $1 $2 $3"


### PR DESCRIPTION
https://www.vagrantup.com/docs/boxes#official-boxes

> For other users, we recommend the Bento boxes. The Bento boxes are open source and built for a number of providers including VMware, VirtualBox, and Parallels. There are a variety of operating systems and versions available.
> These (`hashicorp/bionic64` & `bento/*`) are the only two officially-recommended box sets.